### PR TITLE
Change letgo group to codely of ImportOrderCheckerRule (scalastyle)

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -212,7 +212,7 @@ This file is divided into 3 sections:
 
     <check level="error" class="org.scalastyle.scalariform.ImportOrderChecker" enabled="true">
         <parameters>
-            <parameter name="groups">java,scala,play,3rdParty,letgo</parameter>
+            <parameter name="groups">java,scala,play,3rdParty,codely</parameter>
             <parameter name="group.java">javax?\..*</parameter>
             <parameter name="group.scala">scala\..*</parameter>
             <parameter name="group.play">play\..*</parameter>


### PR DESCRIPTION
#2 was closed but the groups parameter remained unchanged.

This pull request changes "letgo" to "codelytv" to complete the fix.